### PR TITLE
Setup app navigation with onboarding and tabs

### DIFF
--- a/apps/mobile/app/(onboarding)/_layout.tsx
+++ b/apps/mobile/app/(onboarding)/_layout.tsx
@@ -1,0 +1,31 @@
+import { Stack } from 'expo-router';
+
+export default function OnboardingLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: true,
+        headerStyle: {
+          backgroundColor: '#f5f5f5',
+        },
+        headerTintColor: '#333',
+        headerTitleStyle: {
+          fontWeight: 'bold',
+        },
+      }}>
+      <Stack.Screen
+        name="getting-started"
+        options={{
+          title: 'Welcome to Blob',
+          headerShown: false,
+        }}
+      />
+      <Stack.Screen
+        name="login"
+        options={{
+          title: 'Login',
+        }}
+      />
+    </Stack>
+  );
+}

--- a/apps/mobile/app/(onboarding)/getting-started.tsx
+++ b/apps/mobile/app/(onboarding)/getting-started.tsx
@@ -1,0 +1,24 @@
+import { View, Text, Pressable } from 'react-native';
+import { router } from 'expo-router';
+
+export default function GettingStartedScreen() {
+  return (
+    <View className="flex-1 justify-between bg-blue-50 p-6">
+      <View className="flex-1 items-center justify-center">
+        <Text className="mb-3 text-center text-3xl font-bold text-blue-600">Welcome to Blob</Text>
+        <Text className="mb-6 text-center text-xl text-gray-700">
+          Your AI-Powered Study Companion
+        </Text>
+        <Text className="px-5 text-center text-base leading-6 text-gray-600">
+          Transform your study materials into interactive flashcards, mind maps, and quizzes
+        </Text>
+      </View>
+
+      <Pressable
+        className="mb-5 items-center rounded-xl bg-blue-600 px-8 py-4"
+        onPress={() => router.push('/(onboarding)/login')}>
+        <Text className="text-lg font-semibold text-white">Get Started</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/app/(onboarding)/login.tsx
+++ b/apps/mobile/app/(onboarding)/login.tsx
@@ -1,0 +1,33 @@
+import { View, Text, Pressable } from 'react-native';
+import { router } from 'expo-router';
+
+import { useAuthStore } from '@/store/authStore';
+
+export default function LoginScreen() {
+  const login = useAuthStore((state) => state.login);
+
+  const handleLogin = () => {
+    login();
+    router.replace('/(tabs)/home');
+  };
+
+  return (
+    <View className="flex-1 justify-between bg-green-50 p-6">
+      <View className="flex-1 items-center justify-center">
+        <Text className="mb-3 text-center text-3xl font-bold text-green-700">Login</Text>
+        <Text className="mb-6 text-center text-lg text-gray-700">
+          Sign in to continue your learning journey
+        </Text>
+        <Text className="px-5 text-center text-sm italic text-gray-600">
+          (This is a placeholder screen. Tap the button below to simulate login)
+        </Text>
+      </View>
+
+      <Pressable
+        className="mb-5 items-center rounded-xl bg-green-700 px-8 py-4"
+        onPress={handleLogin}>
+        <Text className="text-lg font-semibold text-white">Login</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,0 +1,47 @@
+import { Tabs } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+
+export default function TabsLayout() {
+  return (
+    <Tabs
+      screenOptions={{
+        headerShown: true,
+        tabBarActiveTintColor: '#1976D2',
+        tabBarInactiveTintColor: '#999',
+        tabBarStyle: {
+          backgroundColor: '#fff',
+          borderTopWidth: 1,
+          borderTopColor: '#e0e0e0',
+          height: 60,
+          paddingBottom: 8,
+          paddingTop: 8,
+        },
+        tabBarLabelStyle: {
+          fontSize: 12,
+          fontWeight: '600',
+        },
+      }}>
+      <Tabs.Screen
+        name="home"
+        options={{
+          title: 'Home',
+          tabBarIcon: ({ color, size }) => <Ionicons name="home" size={size} color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="explore"
+        options={{
+          title: 'Explore',
+          tabBarIcon: ({ color, size }) => <Ionicons name="compass" size={size} color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="profile"
+        options={{
+          title: 'Profile',
+          tabBarIcon: ({ color, size }) => <Ionicons name="person" size={size} color={color} />,
+        }}
+      />
+    </Tabs>
+  );
+}

--- a/apps/mobile/app/(tabs)/explore.tsx
+++ b/apps/mobile/app/(tabs)/explore.tsx
@@ -1,0 +1,17 @@
+import { View, Text } from 'react-native';
+
+export default function ExploreScreen() {
+  return (
+    <View className="flex-1 bg-gray-100">
+      <View className="flex-1 items-center justify-center p-6">
+        <Text className="mb-3 text-center text-3xl font-bold text-orange-600">Explore</Text>
+        <Text className="mb-6 text-center text-lg text-gray-700">Discover new study materials</Text>
+        <Text className="px-5 text-center text-sm leading-snug text-gray-600">
+          This is a placeholder for the Explore screen.{'\n'}
+          Future features will include browsing topics, discovering new flashcard sets, and
+          community content.
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/(tabs)/home.tsx
+++ b/apps/mobile/app/(tabs)/home.tsx
@@ -1,0 +1,18 @@
+import { View, Text } from 'react-native';
+
+export default function HomeScreen() {
+  return (
+    <View className="flex-1 bg-white">
+      <View className="flex-1 items-center justify-center p-6">
+        <Text className="mb-3 text-center text-3xl font-bold text-blue-600">Home</Text>
+        <Text className="mb-6 text-center text-lg text-gray-700">
+          Welcome to your study dashboard
+        </Text>
+        <Text className="px-5 text-center text-sm leading-snug text-gray-600">
+          This is a placeholder for the Home screen.{'\n'}
+          Future features will include your recent flashcards, study progress, and quick actions.
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -1,0 +1,34 @@
+import { View, Text, Pressable } from 'react-native';
+import { router } from 'expo-router';
+
+import { useAuthStore } from '@/store/authStore';
+
+export default function ProfileScreen() {
+  const logout = useAuthStore((state) => state.logout);
+
+  const handleLogout = () => {
+    logout();
+    router.replace('/(onboarding)/getting-started');
+  };
+
+  return (
+    <View className="flex-1 justify-between bg-purple-50 p-6">
+      <View className="flex-1 items-center justify-center">
+        <Text className="mb-3 text-center text-3xl font-bold text-purple-700">Profile</Text>
+        <Text className="mb-6 text-center text-lg text-gray-700">
+          Manage your account and settings
+        </Text>
+        <Text className="px-5 text-center text-sm leading-snug text-gray-600">
+          This is a placeholder for the Profile screen.{'\n'}
+          Future features will include user settings, study statistics, and account management.
+        </Text>
+      </View>
+
+      <Pressable
+        className="mb-5 items-center rounded-xl bg-purple-700 px-8 py-4"
+        onPress={handleLogout}>
+        <Text className="text-lg font-semibold text-white">Logout</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,12 +1,12 @@
 import '../global.css';
 
-import { Stack } from 'expo-router';
+import { Slot } from 'expo-router';
 import { TRPCProvider } from '@/utils/TRPCProvider';
 
-export default function Layout() {
+export default function RootLayout() {
   return (
     <TRPCProvider>
-      <Stack />
+      <Slot />
     </TRPCProvider>
   );
 }

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,72 +1,13 @@
-import { Stack, Link } from 'expo-router';
-import { View, Text, ActivityIndicator } from 'react-native';
+import { Redirect } from 'expo-router';
 
-import { Button } from '@/components/Button';
-import { Container } from '@/components/Container';
-import { ScreenContent } from '@/components/ScreenContent';
-import { trpc } from '@/utils/trpc';
-import { getApiUrl } from '@/utils/api';
+import { useAuthStore } from '@/store/authStore';
 
-export default function Home() {
-  const helloQuery = trpc.hello.useQuery({ name: 'React Native' });
-  const timeQuery = trpc.getTime.useQuery();
-  const echoMutation = trpc.echo.useMutation();
-  const handleEcho = () => {
-    echoMutation.mutate({ message: 'Hello from mobile app!' });
-  };
+export default function Index() {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
-  return (
-    <View className={styles.container}>
-      <Stack.Screen options={{ title: 'Home' }} />
-      <Container>
-        <ScreenContent path="app/index.tsx" title="Home">
-          <View className="mt-4 space-y-4">
-            <Text className="text-sm text-gray-600">API URL: {getApiUrl()}</Text>
+  if (isAuthenticated) {
+    return <Redirect href="/(tabs)/home" />;
+  }
 
-            <View className="rounded border border-gray-200 p-4">
-              <Text className="mb-2 font-bold">Hello Query:</Text>
-              {helloQuery.isLoading && <ActivityIndicator />}
-              {helloQuery.error && (
-                <Text className="text-red-500">Error: {helloQuery.error.message}</Text>
-              )}
-              {helloQuery.data && (
-                <Text className="text-green-600">{helloQuery.data.greeting}</Text>
-              )}
-            </View>
-
-            <View className="rounded border border-gray-200 p-4">
-              <Text className="mb-2 font-bold">Server Time Query:</Text>
-              {timeQuery.isLoading && <ActivityIndicator />}
-              {timeQuery.error && (
-                <Text className="text-red-500">Error: {timeQuery.error.message}</Text>
-              )}
-              {timeQuery.data && <Text className="text-blue-600">{timeQuery.data.time}</Text>}
-            </View>
-
-            <View className="rounded border border-gray-200 p-4">
-              <Text className="mb-2 font-bold">Echo Mutation:</Text>
-              <Button
-                title={echoMutation.isPending ? 'Sending...' : 'Test Echo'}
-                onPress={handleEcho}
-              />
-              {echoMutation.error && (
-                <Text className="mt-2 text-red-500">Error: {echoMutation.error.message}</Text>
-              )}
-              {echoMutation.data && (
-                <Text className="mt-2 text-green-600">Response: {echoMutation.data.message}</Text>
-              )}
-            </View>
-
-          </View>
-        </ScreenContent>
-        <Link href={{ pathname: '/details', params: { name: 'Dan' } }} asChild>
-          <Button title="Show Details" />
-        </Link>
-      </Container>
-    </View>
-  );
+  return <Redirect href="/(onboarding)/getting-started" />;
 }
-
-const styles = {
-  container: 'flex flex-1 bg-white',
-};

--- a/apps/mobile/contributors.ts
+++ b/apps/mobile/contributors.ts
@@ -1,13 +1,13 @@
 type Contributor = {
-  name: string,
-  github: string,
-  twitter?: string | undefined,
-  website?: string | undefined
-}
+  name: string;
+  github: string;
+  twitter?: string | undefined;
+  website?: string | undefined;
+};
 
 export const CONTRIBUTORS: Contributor[] = [
   {
-    name: "Pranshu Sethi",
-    github: "iampranshusethi",
-  }
-]
+    name: 'Pranshu Sethi',
+    github: 'iampranshusethi',
+  },
+];

--- a/apps/mobile/store/authStore.ts
+++ b/apps/mobile/store/authStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+export interface AuthState {
+  isAuthenticated: boolean;
+  login: () => void;
+  logout: () => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  isAuthenticated: false,
+  login: () => set({ isAuthenticated: true }),
+  logout: () => set({ isAuthenticated: false }),
+}));


### PR DESCRIPTION
## Summary
This PR implements the dual-phase navigation structure for the Blob mobile app as requested in issue #5.

## What's Changed
✅ **Onboarding Flow** - Stack navigator with two screens:
- Getting Started screen (welcome page)
- Login screen (mock authentication)

✅ **Main App Flow** - Bottom tab navigator with three tabs:
- Home tab (dashboard placeholder)
- Explore tab (discovery placeholder)  
- Profile tab (user settings placeholder)

✅ **Authentication State** - Zustand store for managing login/logout
✅ **Conditional Routing** - App shows onboarding before auth, tabs after auth
✅ **NativeWind CSS** - All screens use NativeWind CSS classes for consistency

## Technical Implementation
- Used Expo Router with route groups `(onboarding)` and `(tabs)`
- Created `authStore` using Zustand for state management
- Each screen has placeholder UI with distinct colors
- All styling uses NativeWind CSS (no StyleSheet)
- Clean, maintainable structure ready for future features

## File Structure
```
apps/mobile/
├── app/
│   ├── (onboarding)/
│   │   ├── _layout.tsx
│   │   ├── getting-started.tsx
│   │   └── login.tsx
│   ├── (tabs)/
│   │   ├── _layout.tsx
│   │   ├── home.tsx
│   │   ├── explore.tsx
│   │   └── profile.tsx
│   ├── _layout.tsx
│   └── index.tsx
└── store/
    └── authStore.ts
```

## Testing
- ✅ App launches on Getting Started screen
- ✅ Navigation flow works: Getting Started → Login → Tabs
- ✅ All three tabs are accessible and render correctly
- ✅ Logout returns to onboarding flow
- ✅ Code formatted with Prettier
- ✅ No merge conflicts with main
- ✅ All screens use NativeWind CSS

## Addresses Maintainer Feedback
- ✅ Converted all screens from StyleSheet to NativeWind CSS for consistency
- ✅ Assigned to issue #5 before creating PR

issue: #5