### PR TITLE
feat(db): implement User schema for Google OAuth

### DIFF
--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,1 +1,2 @@
 export * from "./users";
+export * from "./oauthAccounts";

--- a/packages/db/src/schema/oauthAccounts.ts
+++ b/packages/db/src/schema/oauthAccounts.ts
@@ -1,0 +1,25 @@
+import { pgTable, text, timestamp, uuid, primaryKey } from "drizzle-orm/pg-core";
+import { users } from "./users";
+
+export const oauthAccounts = pgTable(
+  "oauth_accounts",
+  {
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    providerId: text("provider_id").notNull(), 
+    providerUserId: text("provider_user_id").notNull(), 
+    accessToken: text("access_token"), 
+    refreshToken: text("refresh_token"), 
+    expiresAt: timestamp("expires_at"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+    lastLoginAt: timestamp("last_login_at"),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.providerId, table.providerUserId] }),
+  })
+);
+
+export type OAuthAccount = typeof oauthAccounts.$inferSelect;
+export type NewOAuthAccount = typeof oauthAccounts.$inferInsert;

--- a/packages/db/src/schema/users.ts
+++ b/packages/db/src/schema/users.ts
@@ -4,6 +4,7 @@ export const users = pgTable("users", {
   id: uuid("id").defaultRandom().primaryKey(),
   name: text("name").notNull(),
   email: text("email").notNull().unique(),
+  image: text("image"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });


### PR DESCRIPTION
issue: #22

---

##  Description

Implemented the database schema changes required for Google OAuth authentication.
- **Updated `users` table**: Added an `image` field to store the profile photo URL.
- **Created `oauth_accounts` table**: A new table to map external providers (like Google) to internal users, storing provider IDs and tokens.
- **Generated Migration**: Included the Drizzle SQL migration file.

This schema safely links external Google identities to our Blob users.

