### PR TITLE
feat(db): create quizzes table(s)

### DIFF
--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -3,3 +3,4 @@ export * from "./oauthAccounts";
 export * from "./topics";
 export * from "./flashcards";
 export * from "./mindMaps";
+export * from "./quizzes";

--- a/packages/db/src/schema/quizzes.ts
+++ b/packages/db/src/schema/quizzes.ts
@@ -1,0 +1,58 @@
+import { index, pgTable, text, timestamp, uuid, boolean } from "drizzle-orm/pg-core";
+import { topics } from "./topics";
+
+export const quizzes = pgTable("quizzes", {
+        id: uuid("id").defaultRandom().primaryKey(),
+        topicId: uuid("topic_id")
+            .notNull()
+            .references(() => topics.id, { onDelete: "cascade" }),
+        title: text("title").notNull(),
+        description: text("description"),
+        createdAt: timestamp("created_at").defaultNow().notNull(),
+        updatedAt: timestamp("updated_at")
+            .defaultNow()
+            .notNull()
+            .$onUpdate(() => new Date()),
+    },
+    (table) => ({
+        topicIdx: index("quizzes_topic_id_idx").on(table.topicId)
+    })
+);
+
+export const quizQuestions = pgTable("quiz_questions", {
+        id: uuid("id").defaultRandom().primaryKey(),
+        quizId: uuid("quiz_id")
+            .notNull()
+            .references(() => quizzes.id, { onDelete: "cascade" }),
+        question: text("question").notNull(),
+        createdAt: timestamp("created_at").defaultNow().notNull(),
+        updatedAt: timestamp("updated_at")
+            .defaultNow()
+            .notNull()
+            .$onUpdate(() => new Date()),
+    },
+    (table) => ({
+        quizIdx: index("quiz_questions_quiz_id_idx").on(table.quizId)
+    })
+);
+
+export const quizOptions = pgTable("quiz_options", {
+        id: uuid("id").defaultRandom().primaryKey(),
+        questionId: uuid("question_id")
+            .notNull()
+            .references(() => quizQuestions.id, { onDelete: "cascade" }),
+        optionText: text("option_text").notNull(),
+        isCorrect: boolean("is_correct").default(false).notNull(),
+        createdAt: timestamp("created_at").defaultNow().notNull(),
+    },
+    (table) => ({
+        questionIdx: index("quiz_options_question_id_idx").on(table.questionId)
+    })
+);
+
+export type Quiz = typeof quizzes.$inferSelect;
+export type NewQuiz = typeof quizzes.$inferInsert;
+export type QuizQuestion = typeof quizQuestions.$inferSelect;
+export type NewQuizQuestion = typeof quizQuestions.$inferInsert;
+export type QuizOption = typeof quizOptions.$inferSelect;
+export type NewQuizOption = typeof quizOptions.$inferInsert;


### PR DESCRIPTION
## Summary
Adds database schema for topic-based quizzes as requested in #52.

## Changes
- **quizzes** - stores quiz metadata (title, description) linked to a topic
- **quiz_questions** - stores questions belonging to a quiz
- **quiz_options** - stores multiple choice options with `isCorrect` flag

## Schema Design

## Features
- UUID primary keys
- Foreign keys with cascade deletes
- Timestamps (created_at, updated_at)
- Indexes on all foreign keys for query performance
- TypeScript types exported for all tables

## Note
Used `isCorrect` boolean on options instead of `correct_answer` on questions - this allows multiple correct answers and keeps data normalized.

Issue: #52
