### PR TITLE
resolve bottom tab overlap with system nav bar

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,11 +1,13 @@
 import { Tabs } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useColorScheme } from 'nativewind';
+import { Platform } from 'react-native';
 
 export default function TabsLayout() {
   const { colorScheme } = useColorScheme();
   const isDark = colorScheme === 'dark';
-
+  const insets = useSafeAreaInsets();
   return (
     <Tabs
       screenOptions={{
@@ -19,6 +21,8 @@ export default function TabsLayout() {
           borderTopWidth: 1,
           borderTopColor: isDark ? '#222' : '#e0e0e0',
           paddingTop: 8,
+          paddingBottom: insets.bottom, 
+          height: Platform.OS === 'android' ? 60 + insets.bottom : 88,
         },
 
         tabBarLabelStyle: {


### PR DESCRIPTION
issue: #65

---

##  Description

Describe what this PR does and why.
this PR solves the UI problem of overlaping of bottom tab with system nav bar. 
it uses useSafeAreaInsets to detect how many pixels android nav bar uses.
it adds paddingBottom into the Tab Bar style.
It dynamically increases the height of the Tab Bar on Android.
---
